### PR TITLE
removed warnings hidden by suppressWarning all closes #127

### DIFF
--- a/src/main/java/fluent/ly/box.java
+++ b/src/main/java/fluent/ly/box.java
@@ -25,7 +25,7 @@ import il.org.spartan.*;
     return Boolean.valueOf(¢);
   }
 
-  @NotNull public static Boolean[] box(final boolean bs[]) {
+  public static Boolean @NotNull [] box(final boolean bs[]) {
     final Boolean[] $ = new Boolean[bs.length];
     for (int ¢ = 0; ¢ < $.length; ++¢)
       $[¢] = box(bs[¢]);
@@ -36,7 +36,7 @@ import il.org.spartan.*;
     return cantBeNull(Utils.canBeNull(Byte.valueOf(¢)));
   }
 
-  @NotNull public static Byte[] box(final byte bs[]) {
+  public static Byte @NotNull [] box(final byte bs[]) {
     final Byte @NotNull [] $ = new Byte[bs.length];
     for (int ¢ = 0; ¢ < $.length; ++¢)
       $[¢] = box(bs[¢]);
@@ -51,7 +51,7 @@ import il.org.spartan.*;
     return Character.valueOf(¢);
   }
 
-  @NotNull public static Character[] box(final char cs[]) {
+  public static Character @NotNull [] box(final char cs[]) {
     final Character @NotNull [] $ = new Character[cs.length];
     for (int ¢ = 0; ¢ < $.length; ++¢)
       $[¢] = box(cs[¢]);
@@ -66,7 +66,7 @@ import il.org.spartan.*;
     return Double.valueOf(¢);
   }
 
-  @NotNull public static Double[] box(final double ds[]) {
+  public static Double @NotNull [] box(final double ds[]) {
     final Double @NotNull [] $ = new Double[ds.length];
     for (int ¢ = 0; ¢ < $.length; ++¢)
       $[¢] = box(ds[¢]);
@@ -107,7 +107,7 @@ import il.org.spartan.*;
     return cantBeNull(Long.valueOf(¢));
   }
 
-  @NotNull public static Long[] box(final long ls[]) {
+  public static Long @NotNull [] box(final long ls[]) {
     final Long @NotNull [] $ = new Long[ls.length];
     for (int ¢ = 0; ¢ < $.length; ++¢)
       $[¢] = box(ls[¢]);
@@ -122,7 +122,7 @@ import il.org.spartan.*;
     return Short.valueOf(¢);
   }
 
-  @NotNull public static Short[] box(final short ss[]) {
+  public static Short @NotNull [] box(final short ss @NotNull []) {
     final Short @NotNull [] $ = new Short[ss.length];
     for (int ¢ = 0; ¢ < $.length; ++¢)
       $[¢] = box(ss[¢]);

--- a/src/main/java/fluent/ly/unbox.java
+++ b/src/main/java/fluent/ly/unbox.java
@@ -1,5 +1,6 @@
 package fluent.ly;
 
+import static il.org.spartan.Utils.*;
 import java.util.*;
 
 import org.jetbrains.annotations.*;
@@ -27,11 +28,11 @@ import org.jetbrains.annotations.*;
 @SuppressWarnings("all") public enum unbox {
   // A namespace: no values to this <code><b>enum</b></code>
   ;
-  public static double @NotNull [] it(final @NotNull Double[] ¢) {
+  public static double @NotNull [] it(final Double @NotNull [] ¢) {
     return unbox(¢);
   }
 
-  public static float @NotNull [] it(final Float[] ¢) {
+  public static float @NotNull [] it(final Float @NotNull [] ¢) {
     return unbox(¢);
   }
 
@@ -39,12 +40,12 @@ import org.jetbrains.annotations.*;
     return ¢.intValue();
   }
 
-  public static int @NotNull [] it(final @NotNull Integer[] ¢) {
+  public static int @NotNull [] it(final Integer @NotNull [] ¢) {
     return unbox(¢);
   }
 
   public static int @NotNull [] it(final @NotNull List<Integer> ¢) {
-    return it(¢.toArray(new @NotNull Integer[¢.size()]));
+    return it(cantBeNull(¢.toArray(new Integer[¢.size()])));
   }
 
   public static boolean unbox(final @NotNull Boolean ¢) {
@@ -55,7 +56,7 @@ import org.jetbrains.annotations.*;
    * <code><b>boolean</b></code>s.
    * @param bs an array of {@link Boolean}s
    * @return an equivalent array of <code><b>boolean</b></code>s. */
-  public static boolean @NotNull [] unbox(final @NotNull Boolean[] bs) {
+  public static boolean @NotNull [] unbox(final Boolean @NotNull [] bs) {
     final boolean @NotNull [] $ = new boolean[bs.length];
     for (int ¢ = 0; ¢ < bs.length; ++¢)
       $[¢] = bs[¢].booleanValue();
@@ -69,7 +70,7 @@ import org.jetbrains.annotations.*;
   /** unbox an array of {@link Byte}s into an array of <code><b>byte</b></code> s.
    * @param bs an array of {@link Byte}s
    * @return an equivalent array of <code><b>byte</b></code>s. */
-  public static byte @NotNull [] unbox(final @NotNull Byte[] bs) {
+  public static byte @NotNull [] unbox(final Byte @NotNull [] bs) {
     final byte @NotNull [] $ = new byte[bs.length];
     for (int ¢ = 0; ¢ < bs.length; ++¢)
       $[¢] = bs[¢].byteValue();
@@ -84,7 +85,7 @@ import org.jetbrains.annotations.*;
    * <code><b>char</b></code>s.
    * @param cs an array of {@link Character}s
    * @return an equivalent array of <code><b>char</b></code>s. */
-  public static char @NotNull [] unbox(final @NotNull Character[] cs) {
+  public static char @NotNull [] unbox(final Character @NotNull [] cs) {
     final char @NotNull [] $ = new char[cs.length];
     for (int ¢ = 0; ¢ < cs.length; ++¢)
       $[¢] = cs[¢].charValue();
@@ -111,7 +112,7 @@ import org.jetbrains.annotations.*;
    * <code><b>double</b></code>s.
    * @param ds an array of {@link Double}s
    * @return an equivalent array of <code><b>double</b></code>s. */
-  public static double @NotNull [] unbox(final @NotNull Double[] ds) {
+  public static double @NotNull [] unbox(final Double @NotNull [] ds) {
     final double @NotNull [] $ = new double[ds.length];
     for (int ¢ = 0; ¢ < ds.length; ++¢)
       $[¢] = ds[¢].floatValue();
@@ -126,7 +127,7 @@ import org.jetbrains.annotations.*;
    * s.
    * @param fs an array of {@link Float}s
    * @return an equivalent array of <code><b>float</b></code>s. */
-  public static float @NotNull [] unbox(final Float[] fs) {
+  public static float @NotNull [] unbox(final Float @NotNull [] fs) {
     final float @NotNull [] $ = new float[fs.length];
     for (int ¢ = 0; ¢ < fs.length; ++¢)
       $[¢] = fs[¢].floatValue();
@@ -141,7 +142,7 @@ import org.jetbrains.annotations.*;
    * s.
    * @param is an array of {@link Integer}s
    * @return an equivalent array of <code><b>int</b></code>s. */
-  public static int @NotNull [] unbox(final @NotNull Integer[] is) {
+  public static int @NotNull [] unbox(final Integer @NotNull [] is) {
     final int @NotNull [] $ = new int[is.length];
     for (int ¢ = 0; ¢ < is.length; ++¢)
       $[¢] = is[¢].intValue();
@@ -155,7 +156,7 @@ import org.jetbrains.annotations.*;
   /** unbox an array of {@link Long}s into an array of <code><b>long</b></code> s.
    * @param ls an array of {@link Long}s
    * @return an equivalent array of <code><b>long</b></code>s. */
-  public static long @NotNull [] unbox(final @NotNull Long[] ls) {
+  public static long @NotNull [] unbox(final Long @NotNull [] ls) {
     final long @NotNull [] $ = new long[ls.length];
     for (int ¢ = 0; ¢ < ls.length; ++¢)
       $[¢] = ls[¢].longValue();
@@ -170,7 +171,7 @@ import org.jetbrains.annotations.*;
    * s.
    * @param ss an array of {@link Integer}s
    * @return an equivalent array of <code><b>short</b></code>s. */
-  public static short @NotNull [] unbox(final @NotNull Short[] ss) {
+  public static short @NotNull [] unbox(final Short @NotNull [] ss) {
     final short @NotNull [] $ = new short[ss.length];
     for (int ¢ = 0; ¢ < ss.length; ++¢)
       $[¢] = ss[¢].shortValue();

--- a/src/main/java/il/org/spartan/AbstractStringProperties.java
+++ b/src/main/java/il/org/spartan/AbstractStringProperties.java
@@ -1,6 +1,6 @@
 package il.org.spartan;
 
-import static il.org.spartan.Utils.*;
+import static il.org.spartan.Utils.cantBeNull;
 
 import java.util.*;
 

--- a/src/test/java/fluent/ly/unboxTest.java
+++ b/src/test/java/fluent/ly/unboxTest.java
@@ -48,7 +48,7 @@ import org.junit.*;
   @Test public void testShorts() {
     final short[] arr = { 1, 2, 3, 4, 5, 6 };
     short[] res;
-    final @NotNull Short[] arrShort = box(arr);
+    final Short @NotNull [] arrShort = box(arr);
     azzert.that(unbox(cantBeNull(box((short) 5))), is(5));
     res = unbox(arrShort);
     azzert.that(res.length, is(arr.length));
@@ -60,7 +60,7 @@ import org.junit.*;
   @Test public void testBytes() {
     final byte[] arr = { 1, 2, 3, 4, 5, 6 };
     byte[] res;
-    @NotNull final Byte[] arrByte = box(arr);
+    final Byte @NotNull [] arrByte = box(arr);
     azzert.that(unbox(cantBeNull(box((byte) 5))), is(5));
     res = unbox(arrByte);
     azzert.that(res.length, is(arr.length));
@@ -71,7 +71,7 @@ import org.junit.*;
 
   @Test public void testDoubles() {
     final double[] arr = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
-    final @NotNull Double[] arrDouble = box(arr);
+    final Double @NotNull [] arrDouble = box(arr);
     double[] res = unbox.it(arrDouble);
     azzert.that(res.length, is(arr.length));
     int j = 0;
@@ -103,7 +103,7 @@ import org.junit.*;
 
   @Test public void testBools() {
     final boolean[] arr = { true, false, true, true, false, false };
-    final @NotNull Boolean[] arrBool = box(arr);
+    final Boolean @NotNull [] arrBool = box(arr);
     assert unbox(cantBeNull(Boolean.TRUE));
     assert !unbox(cantBeNull(Boolean.FALSE));
     final boolean[] res = unbox(arrBool);
@@ -115,7 +115,7 @@ import org.junit.*;
 
   @Test public void testLongs() {
     final long[] arr = { 1, 2, 3, 4, 5, 6 };
-    @NotNull final Long[] arrLong = box(arr);
+    final Long @NotNull [] arrLong = box(arr);
     assert unbox(box(5l)) == 5l;
     final long[] res = unbox(arrLong);
     azzert.that(res.length, is(arr.length));
@@ -126,7 +126,7 @@ import org.junit.*;
 
   @Test public void testChars() {
     final char[] arr = { 1, 2, 3, 4, 5, 6 };
-    final @NotNull Character[] arrChar = box(arr);
+    final Character @NotNull [] arrChar = box(arr);
     azzert.that(unbox(cantBeNull(box((char) 5))), is(5));
     final char[] res = unbox(arrChar);
     azzert.that(res.length, is(arr.length));


### PR DESCRIPTION
Removed the suppressWarning anotation.
Fixed all warnings that can be fixed.
Returned the anotation because it's the only way to deal with functions same name as class.